### PR TITLE
Update arguments for devtools 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat,
-    devtools
+    devtools (>= 2.0.0)
 License: GPL (>= 2)
 LazyData: true
 URL: https://github.com/brodieG/unitizer

--- a/tests/testthat/testthat.utz1.R
+++ b/tests/testthat/testthat.utz1.R
@@ -17,7 +17,7 @@ local({
   context("Unitize")
 
   update_fastlm(.unitizer.fastlm, "0.1.0")
-  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, local=FALSE)
+  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, build=TRUE)
   test.dir <- file.path(.unitizer.fastlm, "tests", "unitizer")
   unlink(.unitizer.test.store, recursive=TRUE)
 
@@ -308,7 +308,7 @@ local({
   # Update `fastlm` to cause unitizers to fail, and go through the errors
 
   update_fastlm(.unitizer.fastlm, version="0.1.1")
-  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, local=FALSE)
+  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, build=TRUE)
 
   # Try navigating through the unitizer
 
@@ -440,7 +440,7 @@ local({
   # Upgrade again, and try with deleted tests and other things
 
   update_fastlm(.unitizer.fastlm, version="0.1.2")
-  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, local=FALSE)
+  devtools::install(.unitizer.fastlm, quick=TRUE, quiet=TRUE, build=TRUE)
   unitizer:::read_line_set_vals(
     c("3", "ref(res)", "Y", "Y", "B", "1", "B", "U", "Y", "RR", "Y", "Q")
   )


### PR DESCRIPTION
devtools 2.0.0 removes the `local` argument in favor of `build`. The previous `local = FALSE` is approximately equal to `build = TRUE`.

This PR simply makes this change, which fixes the unitizer tests with devtools 2.0.0.

I plan to submit devtools to CRAN within the next week or so.