### PR TITLE
family->given for R Core authorship

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
     "Michael", "https://github.com/MichaelChirico", 
     email="michaelchirico4@gmail.com",
     role=c("ctb")),
-    person(family="R Core Team",
+    person(given="R Core Team",
     email="R-core@r-project.org", role="cph",
     comment="Traceback function sources."
     )    )


### PR DESCRIPTION
This is the more typical and correct way to cite this contributor.

c.f.

```r
a = tools::CRAN_authors_db()
sum(grepl("(?i)r core team", a$family))
# [1] 8
sum(grepl("(?i)r core team", a$given))
# [1] 61
```

From `?person`:

> For persons which are not natural persons (e.g., institutions, companies, etc.) it is appropriate to use `given` (but not `family`) for the name, e.g., `person("R Core Team", role = "aut")`.